### PR TITLE
fix script printing multiple lines

### DIFF
--- a/bluetooth.sh
+++ b/bluetooth.sh
@@ -6,7 +6,8 @@ else
   if [ $(echo info | bluetoothctl | grep 'Device' | wc -c) -eq 0 ]
   then 
     echo ""
+  else
+    echo "%{F#2193ff}"
   fi
-  echo "%{F#2193ff}"
 fi
 


### PR DESCRIPTION
When bluetooth is powered-on & device-not-connected, bluetooth.sh prints two lines. This commit
is to fix this by moving powered-on & device-connected state to the else
clause of the if statement.